### PR TITLE
News Date Fix

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,0 +1,18 @@
+# Adapted from https://github.com/docker/awesome-compose/blob/master/flask/app/Dockerfile
+# syntax=docker/dockerfile:1.4
+FROM python:3.10-alpine AS builder
+
+WORKDIR /app
+
+COPY requirements.txt /app
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip3 install -r requirements.txt
+
+COPY . /app
+
+EXPOSE 80/udp
+EXPOSE 80/tcp
+
+ENTRYPOINT ["python3"]
+CMD ["app.py"]
+

--- a/app/app.py
+++ b/app/app.py
@@ -30,7 +30,7 @@ def getNews(mpName):
             data = data["response"]["results"]
             for i in data:
                 iDate = i["webPublicationDate"]
-                iDate = iDate[0:9]
+                iDate = iDate[0:10]
                 iNews = newsItem(i["webTitle"],iDate,i["webUrl"])
                 newsResults.append(iNews)
             return newsResults


### PR DESCRIPTION
Another issue noticed by Mo. The dates pulled in from the news api are incorrectly parsed causing the last digit to be cut off. This has been fixed

![image](https://user-images.githubusercontent.com/11465134/217302769-bdaa5a7b-b655-4f80-b638-b7e73f897271.png)
