### PR TITLE
Add Alt Text to Image for Accessibility

### DIFF
--- a/app/templates/results.html
+++ b/app/templates/results.html
@@ -13,7 +13,7 @@
         <p>Constituency : {{constituency}}</p>
         <p>Your MP is : {{mpName}}</p>
         <p>{{mpName}} is a {{mpParty}} member</p>
-        <img src="{{mpImgUrl}}" width="200">
+        <img src="{{mpImgUrl}}" width="200" alt="Image of {{mpName}}">
     </div>
     <input type="button" onclick="location.href='/';" value="Return To Search" />
     <div class="news">


### PR DESCRIPTION
Adding alt text to images is an essential accessibility practice. It ensures that users with visual impairments or those who use screen readers can understand the content of the image.

I have updated the code to include alt text for the image of the MP displayed in results.html.

I believe that this change will make the project more inclusive and accessible to a wider audience. Please let me know if there is anything else I can do to assist with the merge process.